### PR TITLE
#35 feat: 왼쪽 바 메뉴의 default state값을 변경함

### DIFF
--- a/src/pages/store/LeftMenu/LeftMenu.js
+++ b/src/pages/store/LeftMenu/LeftMenu.js
@@ -21,7 +21,7 @@ const LeftMenuStyle = styled.div`
 
 export default function LeftMenu() {
   const [menuOpen, setMenuOpen] = useState(true);
-  const [filterOpen, setFilterOpen] = useState(true);
+  const [filterOpen, setFilterOpen] = useState(false);
 
   return (
     <>


### PR DESCRIPTION
매장 찾기 페이지를 들어가면 왼쪽 바 메뉴가 기본적으로 닫혀있는 버그를 발견함. 그래서 default state값을 변경함.